### PR TITLE
Draft: add DarkMode

### DIFF
--- a/src/main/java/com/github/cptblacksheep/launchofexile/datamanagement/JsonSerializer.java
+++ b/src/main/java/com/github/cptblacksheep/launchofexile/datamanagement/JsonSerializer.java
@@ -122,6 +122,11 @@ public class JsonSerializer {
             PoeVersion poeVersion = mapper.convertValue(part.textValue(), PoeVersion.class);
             settings.setSelectedPoeVersion(poeVersion);
 
+            part = jsonNode.get("darkModeEnabled");
+
+            boolean darkMode = part.booleanValue();
+            settings.setDarkModeEnabled(darkMode);
+
         } catch (IOException | RuntimeException ex) {
             JOptionPane.showMessageDialog(null, "Failed to load settings",
                     "Launch of Exile - Error", JOptionPane.ERROR_MESSAGE);

--- a/src/main/java/com/github/cptblacksheep/launchofexile/datamanagement/Settings.java
+++ b/src/main/java/com/github/cptblacksheep/launchofexile/datamanagement/Settings.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 public class Settings {
     private String poeExeLocation = "";
     private PoeVersion selectedPoeVersion = PoeVersion.STEAM;
+    private boolean darkModeEnabled;
 
     public String getPoeExeLocation() {
         return poeExeLocation;
@@ -21,4 +22,8 @@ public class Settings {
     public void setSelectedPoeVersion(PoeVersion selectedPoeVersion) {
         this.selectedPoeVersion = Objects.requireNonNull(selectedPoeVersion);
     }
+
+    public boolean getDarkModeEnabled() { return darkModeEnabled; }
+
+    public void setDarkModeEnabled(boolean value) { this.darkModeEnabled = value; }
 }


### PR DESCRIPTION
League is about to start so I won't finish this tonight :) Take it as inspiration, in it's current stage.


This PR adds `darkModeEnabled` to the settings.json file, and will launch the app with a dark theme if its true.

The way we fetch the settings in this branch is not ideal, would need some restructuring.

 You could add a UI button to swap between FlatDarculaLaf and FlatLightLaf, which would also save it in settings and then dispose of the JFrame and re-initialize with the new theme.
